### PR TITLE
Repo script improvements

### DIFF
--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -40,7 +40,9 @@ repo() {
 
 	# if target is not empty
 	if [ -n "$target" ]; then
-		cd "$target" || return 1
+		# get absolute path to resolve symlinks
+		local absolute_target="${target:A}"
+		cd "$absolute_target" || return 1
 	else
 		echo "Repository not found: $1"
 		return 1

--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -3,6 +3,29 @@
 # define global array so completions will have access to the variable
 typeset -ga sources_dirs=("$HOME/cs")
 
+repo_find_match() {
+  local search_term="$1"
+  local pathname base
+
+  # loop over all sources directories
+  for dir in "${sources_dirs[@]}"; do
+    while IFS= read -r pathname; do
+	  # check if path is a directory or symlink to a directory
+      [[ -d "$pathname" ]] || continue
+	  # extract basename and convert to lowercase
+      base="${pathname:t:l}"
+      if [[ "$base" == "$search_term" ]]; then
+	    # return match
+		REPLY="$pathname"
+        return 0
+      fi
+	# search for directories and symlinks only one level deep in $dir, and search case-insensitively
+    done < <(fd "$search_term" "$dir" --max-depth 1 --type d --type l --ignore-case)
+  done
+
+  return 1
+}
+
 repo() {
 	# if no args or too many args passed
 	if [ $# -ne 1 ]; then
@@ -11,16 +34,9 @@ repo() {
 	fi
 
 	# convert query into lowercase
-	local search_term=$(echo "$1" | tr '[:upper:]' '[:lower:]')
-	local target=""
-
-	# loop over all sources directories
-	for dir in "${sources_dirs[@]}"; do
-		# search for directories and symlinks only one level deep in $dir, and search case-insensitively
-		target=$(find "$dir" -maxdepth 1 \( -type d -o -type l \) -iname "*$search_term*" | head -n 1)
-		# if we find the target, then break
-		[[ -n "$target" ]] && break
-	done
+	local search_term="${1:l}"
+	repo_find_match "$search_term"
+	local target=$REPLY
 
 	# if target is not empty
 	if [ -n "$target" ]; then

--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -4,26 +4,26 @@
 typeset -ga sources_dirs=("$HOME/cs")
 
 repo_find_match() {
-  local search_term="$1"
-  local pathname base
+	local search_term="$1"
+	local pathname base
 
-  # loop over all sources directories
-  for dir in "${sources_dirs[@]}"; do
-    while IFS= read -r pathname; do
-	  # check if path is a directory or symlink to a directory
-      [[ -d "$pathname" ]] || continue
-	  # extract basename and convert to lowercase
-      base="${pathname:t:l}"
-      if [[ "$base" == "$search_term" ]]; then
-	    # return match
-		REPLY="$pathname"
-        return 0
-      fi
-	# search for directories and symlinks only one level deep in $dir, and search case-insensitively
-    done < <(fd "$search_term" "$dir" --max-depth 1 --type d --type l --ignore-case)
-  done
+	# loop over all sources directories
+	for dir in "${sources_dirs[@]}"; do
+		while IFS= read -r pathname; do
+			# check if path is a directory or symlink to a directory
+			[[ -d "$pathname" ]] || continue
+			# extract basename and convert to lowercase
+			base="${pathname:t:l}"
+			if [[ "$base" == "$search_term" ]]; then
+				# return match
+				REPLY="$pathname"
+				return 0
+			fi
+			# search for directories and symlinks only one level deep in $dir, and search case-insensitively
+		done < <(fd "$search_term" "$dir" --max-depth 1 --type d --type l --ignore-case)
+	done
 
-  return 1
+	return 1
 }
 
 repo() {
@@ -53,10 +53,18 @@ _repo_complete() {
 	(( CURRENT == 2 )) || return 1
 
 	local -a repos
+	local pathname base
+
 	# loop over all sources directories
 	for dir in "${sources_dirs[@]}"; do
-		# get just the basenames of all directories and symlinks and remove the first line ($dir)
-		repos+=($(find "$dir" -maxdepth 1 \( -type d -o -type l \) -exec basename {} \; | sed '1d'))
+		while IFS= read -r pathname; do
+			# check if path is a directory or symlink to a directory
+			[[ -d "$pathname" ]] || continue
+			# get just the basename
+			base="${pathname:t}"
+			repos+=("$base")
+			# search for directories and symlinks
+		done < <(fd . "$dir" --max-depth 1 --type d --type l)
 	done
 
 	_describe 'repositories' repos || compadd "${repos[@]}"


### PR DESCRIPTION
There was a bug with the repo script where it would do fuzzy-matching. This is not ideal because typing `repo test` when you have the directories `test` and `test-2` should take you to the former. This has been fixed so only exact matches work now.

Another improvement was made because previously symlinks would work, but would cd you to the symlink itself. This is not ideal because symlinks are nice to have a shorthand for a repo name, but after cd'ing into the directory, it would be better to see the actual directory name. This has also been changed so the path is resolved before cd'ing into it.