### PR TITLE
Return error when repo not found

### DIFF
--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -23,7 +23,7 @@ repo_find_match() {
 		done < <(fd "$search_term" "$dir" --max-depth 1 --type d --type l --ignore-case)
 	done
 
-	return 1
+	REPLY=""
 }
 
 repo() {


### PR DESCRIPTION
If a repo is not found, we should return an error. There was a bug where the $REPLY was persisting from the previous run. Now it will be cleared when a repo is not found.