### PR TITLE
chore: make functions private

### DIFF
--- a/zsh/differ.zsh
+++ b/zsh/differ.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-menu() {
+_differ_menu() {
     printf '\nDiffer menu:\n'
     printf '  1) Edit file 1\n'
     printf '  2) Edit file 2\n'
@@ -18,7 +18,7 @@ differ() {
     file2=$(mktemp)
 
     while true; do
-        menu
+        _differ_menu
         read -r choice
         case $choice in
             1)

--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -3,7 +3,7 @@
 # define global array so completions will have access to the variable
 typeset -ga sources_dirs=("$HOME/cs")
 
-repo_find_match() {
+_repo_find_match() {
 	local search_term="$1"
 	local pathname base
 
@@ -35,7 +35,7 @@ repo() {
 
 	# convert query into lowercase
 	local search_term="${1:l}"
-	repo_find_match "$search_term"
+	_repo_find_match "$search_term"
 	local target=$REPLY
 
 	# if target is not empty


### PR DESCRIPTION
Helper functions in my scripts were previously using somewhat generic names (e.g. `menu()`), which since all functions from sourced scripts are in the global scope, could interfere with other functions. Helper functions should instead be named like `_<main function name>_<helper name>()` (e.g. `_differ_menu()`).