### PR TITLE
chore: add check for extended_glob

### DIFF
--- a/zsh/gallery.zsh
+++ b/zsh/gallery.zsh
@@ -52,8 +52,11 @@ gallery() {
 		return 1
 	fi
 
-	# Check case-insensitively for file extensions, and don't return error if no results
-	setopt extended_glob
+	if ! [[ -o extended_glob ]]; then
+		echo "Please enable extended_glob and retry."
+		return 1
+	fi
+
 	local filetype_pattern images img key
 	filetype_pattern="(${(j:|:)_GALLERY_IMAGE_TYPES})"
 	images=(${~image_dir}/*.(#i)${~filetype_pattern}(.N))


### PR DESCRIPTION
Instead of modifying the zsh settings in the gallery function, we should make it a requirement of using this function that `extended_glob` is enabled.