### PR TITLE
minor: validate programs are installed

### DIFF
--- a/zsh/differ.zsh
+++ b/zsh/differ.zsh
@@ -12,6 +12,12 @@ _differ_menu() {
 }
 
 differ() {
+    # check if git is installed
+    if ! whence git > /dev/null; then
+        echo "Error: git is not installed"
+        return 1
+    fi
+
     local file1 file2 choice
 
     file1=$(mktemp)

--- a/zsh/gallery.zsh
+++ b/zsh/gallery.zsh
@@ -38,6 +38,8 @@ _gallery_delete_image_without_confirmation() {
 }
 
 gallery() {
+	setopt local_options extended_glob
+
 	local image_dir="$1"
 
 	# Check if the directory is provided and exists
@@ -52,8 +54,9 @@ gallery() {
 		return 1
 	fi
 
-	if ! [[ -o extended_glob ]]; then
-		echo "Please enable extended_glob and retry."
+	# Check if the IMAGE_VIEWER program is installed
+	if ! whence "$IMAGE_VIEWER" > /dev/null; then
+		echo "Error: IMAGE_VIEWER program '$IMAGE_VIEWER' is not installed"
 		return 1
 	fi
 

--- a/zsh/repo.zsh
+++ b/zsh/repo.zsh
@@ -43,6 +43,12 @@ _repo_find_match() {
 }
 
 repo() {
+	# check if fd is installed
+	if ! whence fd > /dev/null; then
+		echo "Error: fd is not installed"
+		return 1
+	fi
+
 	local open_flag=0
 	local repo_name
 


### PR DESCRIPTION
The scripts in this repository currently do not validate that the programs they require are actually installed. We should add this validation so users will get a better error message if they do not have a required program installed.

Additionally, the `gallery` function requires that the `extended_glob` zsh option is enabled. Previously the function would return an error if `extended_glob` was disabled, but that required the caller to enable `extended_glob` more globally (e.g. in their `.zshrc`) which could conflict with other programs. A better solution per https://github.com/neilwiborg/scripts/issues/15 is to use a zsh local option. This fix is also included in this PR.